### PR TITLE
Converts Manual StateObject Initialization

### DIFF
--- a/Sources/ObservableConverter/ObservableConverterCommand.swift
+++ b/Sources/ObservableConverter/ObservableConverterCommand.swift
@@ -147,6 +147,25 @@ final class ObservableConverterRewriter: SyntaxRewriter {
         return DeclSyntax(newNode)
     }
     
+    override func visit(_ node: FunctionCallExprSyntax) -> ExprSyntax {
+        guard var simpleTypeID = node.calledExpression.as(DeclReferenceExprSyntax.self) else { return super.visit(node) }
+        guard simpleTypeID.baseName.text == "StateObject" else { return super.visit(node) }
+        
+        let wrappedValueIndex = node.arguments.firstIndex { argument in
+            argument.label?.text == "wrappedValue"
+        }
+        
+        guard let wrappedValueIndex else { return super.visit(node) }
+        
+        simpleTypeID.baseName.tokenKind = .stringSegment("State")
+
+        var newNode = node
+        newNode.calledExpression = ExprSyntax(simpleTypeID)
+        newNode.arguments[wrappedValueIndex].label?.tokenKind = .stringSegment("initialValue")
+        
+        return ExprSyntax(newNode)
+    }
+    
     override func visit(_ node: AttributeSyntax) -> AttributeSyntax {
         guard let simpleTypeID = node.attributeName.as(IdentifierTypeSyntax.self) else { return super.visit(node) }
         


### PR DESCRIPTION
## What it Does

This pull request changes manual instantiation of `StateObject` to be `State` instead. Thanks @mliberatore!

## How I Tested

Tested the following code:
```swift
struct Test2View: View {
    @StateObject private var viewModel: ViewModelTest

    init(store: @autoclosure @escaping () -> ViewModelTest) {
        self._viewModel = StateObject(wrappedValue: store())
    }
    
    var body: some View {
        Text(viewModel.publishedProperty ?? "")
    }
}
```

and saw that it was converted to this code after running the command plugin on the example project:
```swift
struct Test2View: View {
    @State private var viewModel: ViewModelTest

    init(store: @autoclosure @escaping () -> ViewModelTest) {
        self._viewModel = State(initialValue: store())
    }
    
    var body: some View {
        Text(viewModel.publishedProperty ?? "")
    }
}
```

Verified that everything compiled and ran.
