### PR TITLE
`ObservableObject` Inheritance Simple Usage Improvement

### DIFF
--- a/Examples/ObservableObjectConversionExample/ContentView.swift
+++ b/Examples/ObservableObjectConversionExample/ContentView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import Combine
 
 final class ViewModelTest: ObservableObject {
     @Published var publishedProperty: String?

--- a/Examples/ObservableObjectConversionExample/ContentView.swift
+++ b/Examples/ObservableObjectConversionExample/ContentView.swift
@@ -6,15 +6,23 @@
 //
 
 import SwiftUI
+import Combine
 
 final class ViewModelTest: ObservableObject {
     @Published var publishedProperty: String?
 }
 
+protocol ViewStore: ObservableObject {}
+
+final class ContentStore: ViewStore {
+    @Published var state: String?
+}
+
 struct ContentView: View {
     @StateObject private var viewModel = ViewModelTest()
     @EnvironmentObject private var environmentModel: ViewModelTest
-    
+    @ObservedObject var observed: ContentStore
+
     var body: some View {
         VStack {
             Image(systemName: "globe")
@@ -42,5 +50,5 @@ struct ChildView: View {
 }
 
 #Preview {
-    ContentView()
+    ContentView(observed: ContentStore())
 }

--- a/Examples/ObservableObjectConversionExample/ObservableObjectConversionExampleApp.swift
+++ b/Examples/ObservableObjectConversionExample/ObservableObjectConversionExampleApp.swift
@@ -13,7 +13,7 @@ struct ObservableObjectConversionExampleApp: App {
 
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ContentView(observed: ContentStore())
                 .environmentObject(test)
         }
     }

--- a/Sources/ObservableConverter/ObservableConverterCommand.swift
+++ b/Sources/ObservableConverter/ObservableConverterCommand.swift
@@ -77,7 +77,6 @@ final class ObservableObjectRecorder: SyntaxVisitor {
         possibleObservableObjectTypes.forEach { possibleTypeName in
             if genericTypeNames.contains(possibleTypeName) {
                 // TODO: handle going up the tree to find the type being passed
-                print("BOC: Generic found for type name: \(possibleTypeName)")
             } else {
                 observableObjectClassNames.insert(possibleTypeName)
             }

--- a/Sources/ObservableConverter/ObservableConverterCommand.swift
+++ b/Sources/ObservableConverter/ObservableConverterCommand.swift
@@ -33,6 +33,8 @@ struct ObservableConverterCommand: ParsableCommand {
     }
 }
 
+/// A `SyntaxVisitor` that records classes names that are known to be `ObservableObject` classes based on their usage.
+/// This allows us to convert classes even if their inhereitence of `ObservableObject` is indirect.
 final class ObservableObjectRecorder: SyntaxVisitor {
     private(set) var observableObjectClassNames: Set<String> = []
     
@@ -85,6 +87,7 @@ final class ObservableObjectRecorder: SyntaxVisitor {
     }
 }
 
+/// A `SyntaxRewriter` that converts known usage of `ObservableObject` APIs to newer `@Observable` ones.
 final class ObservableConverterRewriter: SyntaxRewriter {
     private let knownClassNames: Set<String>
     


### PR DESCRIPTION
## What it Does

This pull request partially solves the case where a class inherits from `ObservableObject` indirectly through another protocol or class by recording the types used in the relevant property wrappers, since these must be `ObservableObject` conformers. 

## How I Tested

Tested by updating the example code (see below) to include an object that conforms to `ObservableObject` via another protocol, using it in @ObservedObject`, and seeing that it was ultimately converted to use `@Observable`

## Notes

It does not yet handle the case where the type used in the property wrappers is generic on the struct, since that will involve more complex hierarchy walking to find initialization of the struct and see what type is passed in. This is definitely a future possibility, though.
