### PR TITLE
Adds Test Target and Very Basic Initial Test

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,12 @@ let package = Package(
                 .product(name: "SwiftParser", package: "swift-syntax"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser")
             ]),
-        .testTarget(name: "ObservableConverterTests", dependencies: ["ObservableConverter"]),
+        .testTarget(name: "ObservableConverterTests",
+                    dependencies: ["ObservableConverter"],
+                    resources: [
+                        .copy("Resources")
+                    ]
+                   ),
         .plugin(
             name: "Convert Target to Use @Observable",
             capability: .command(

--- a/Package.swift
+++ b/Package.swift
@@ -30,6 +30,7 @@ let package = Package(
                 .product(name: "SwiftParser", package: "swift-syntax"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser")
             ]),
+        .testTarget(name: "ObservableConverterTests", dependencies: ["ObservableConverter"]),
         .plugin(
             name: "Convert Target to Use @Observable",
             capability: .command(

--- a/Sources/ObservableConverter/ObservableConverterCommand.swift
+++ b/Sources/ObservableConverter/ObservableConverterCommand.swift
@@ -3,8 +3,6 @@ import SwiftSyntax
 import SwiftParser
 import ArgumentParser
 
-// TODO: Tests
-
 @main
 struct ObservableConverterCommand: ParsableCommand {
     @Argument(help: "A list of file paths to convert those files to use @Observable.")

--- a/Tests/ObservableConverterTests/ObservableConverterTests.swift
+++ b/Tests/ObservableConverterTests/ObservableConverterTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import ObservableConverter
+
+final class ObservableConverterTests: XCTestCase {
+    func testExample() throws {
+        XCTAssertTrue(true)
+    }
+}

--- a/Tests/ObservableConverterTests/ObservableConverterTests.swift
+++ b/Tests/ObservableConverterTests/ObservableConverterTests.swift
@@ -2,7 +2,25 @@ import XCTest
 @testable import ObservableConverter
 
 final class ObservableConverterTests: XCTestCase {
-    func testExample() throws {
-        XCTAssertTrue(true)
+    func testExampleConversion() throws {
+        let before = Bundle.module.path(forResource: "ContentView-before", ofType: "swift", inDirectory: "Resources")
+        let after = Bundle.module.url(forResource: "ContentView-after", withExtension: "swift", subdirectory: "Resources")
+        
+        let fileToConvertPath = try XCTUnwrap(before)
+        let afterURL = try XCTUnwrap(after)
+        
+        let testingFileToConvertPath = fileToConvertPath.appending(".testing")
+        try FileManager.default.copyItem(atPath: fileToConvertPath, toPath: testingFileToConvertPath)
+        
+        let converterURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath.appending("/ObservableConverter"))
+        let process = try Process.run(converterURL, arguments: [testingFileToConvertPath])
+        process.waitUntilExit()
+        
+        let convertedFileContents = try String(contentsOf: URL(fileURLWithPath: testingFileToConvertPath))
+        let expectedOutput = try String(contentsOf: afterURL)
+
+        try FileManager.default.removeItem(atPath: testingFileToConvertPath)
+        
+        XCTAssertEqual(convertedFileContents, expectedOutput)
     }
 }

--- a/Tests/ObservableConverterTests/Resources/ContentView-after.swift
+++ b/Tests/ObservableConverterTests/Resources/ContentView-after.swift
@@ -1,0 +1,55 @@
+//
+//  ContentView.swift
+//  ObservableObjectConversionExample
+//
+//  Created by Brian Capps on 8/16/23.
+//
+
+import SwiftUI
+
+@Observable
+final class ViewModelTest {
+    var publishedProperty: String?
+}
+
+protocol ViewStore: ObservableObject {}
+
+@Observable
+final class ContentStore: ViewStore {
+    var state: String?
+}
+
+struct ContentView: View {
+    @State private var viewModel = ViewModelTest()
+    @Environment(ViewModelTest.self) private var environmentModel 
+    var observed: ContentStore
+
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+                .foregroundStyle(.tint)
+            
+            Text("Hello, world!")
+                .environment(viewModel)
+            
+            ChildView(model: environmentModel)
+        }
+        .padding()
+    }
+}
+
+struct ChildView: View {
+    var model: ViewModelTest
+    
+    var body: some View {
+        Text(model.publishedProperty ?? "no value set")
+            .onTapGesture {
+                model.publishedProperty = "model value changed"
+            }
+    }
+}
+
+#Preview {
+    ContentView(observed: ContentStore())
+}

--- a/Tests/ObservableConverterTests/Resources/ContentView-before.swift
+++ b/Tests/ObservableConverterTests/Resources/ContentView-before.swift
@@ -1,0 +1,53 @@
+//
+//  ContentView.swift
+//  ObservableObjectConversionExample
+//
+//  Created by Brian Capps on 8/16/23.
+//
+
+import SwiftUI
+
+final class ViewModelTest: ObservableObject {
+    @Published var publishedProperty: String?
+}
+
+protocol ViewStore: ObservableObject {}
+
+final class ContentStore: ViewStore {
+    @Published var state: String?
+}
+
+struct ContentView: View {
+    @StateObject private var viewModel = ViewModelTest()
+    @EnvironmentObject private var environmentModel: ViewModelTest
+    @ObservedObject var observed: ContentStore
+
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+                .foregroundStyle(.tint)
+            
+            Text("Hello, world!")
+                .environmentObject(viewModel)
+            
+            ChildView(model: environmentModel)
+        }
+        .padding()
+    }
+}
+
+struct ChildView: View {
+    @ObservedObject var model: ViewModelTest
+    
+    var body: some View {
+        Text(model.publishedProperty ?? "no value set")
+            .onTapGesture {
+                model.publishedProperty = "model value changed"
+            }
+    }
+}
+
+#Preview {
+    ContentView(observed: ContentStore())
+}


### PR DESCRIPTION
## What it Does

This pull request adds a test target that includes resources for a very simple initial test – two swift files representing state before and after the conversion. The test retrieves those files, copies the before state file to a new location, runs the observable converter passing the new location, and compares the converted file to the expected output.

## How I Tested

Opened the Package.swift file in Xcode and ran the tests with Cmd + U. Verified they passed.

